### PR TITLE
Added `fn post_visit` to `trait Visitor`

### DIFF
--- a/cargo-up/rust-visitor/src/lib.rs
+++ b/cargo-up/rust-visitor/src/lib.rs
@@ -26,10 +26,15 @@ macro_rules! visitor {
                 }
 
                 for child in node.children() {
-                    self.visit(&child, &semantics);
+                    self.visit(&child, semantics);
                 }
+
+                self.post_visit(node, semantics);
             }
-            $(fn $method(&mut self, _: &ast::$node, _semantics: &Semantics) {})*
+
+            fn post_visit(&mut self, _node: &SyntaxNode, _semantics: &Semantics) {}
+
+            $(fn $method(&mut self, _ast: &ast::$node, _semantics: &Semantics) {})*
         }
     };
 }


### PR DESCRIPTION
Often times it is not only important to know when nodes are entered, but also when they are exited.

In order to not utterly pollute the trait I only added a single `fn post_visit`, corresponding to `fn visit` as that's usually enough by matching on `node.kind()`.

### Example:

Project's module structure:
```rust
mod foo {
    // ...
    mod bar {
        // ...
        mod baz {
            // ...
        }
        // ...
    }
    // ...
    mod blee {
        // ...
    }
    // ...
}
```

Desired output:

```plain
foo
-bar
--baz
-blee
```

Required visitor:

```rust
struct ModuleVisitor {
    depth: usize,
}

impl Visitor for ModuleVisitor {
    fn visit_module(&mut self, module: &ast::Module, _semantics: &Semantics) {
        use ra_ap_syntax::ast::NameOwner;
        let name = module.name().unwrap();
        println!("{:->depth$}", name, depth = self.depth);
        self.depth += 1;
    }

    fn post_visit(&mut self, node: &SyntaxNode, _semantics: &Semantics) {
        match node.kind() {
            SyntaxKind::MODULE => self.depth -= 1;
            _ => {}
        }
    }
}
```
