### PR TITLE
Moved walking logic into `SyntaxNode` via non-pub `trait Visitable`

### DIFF
--- a/cargo-up/src/lib/runner.rs
+++ b/cargo-up/src/lib/runner.rs
@@ -112,7 +112,7 @@ impl Runner {
                 let source_file = semantics.parse(file_id);
                 // println!("{:#?}", source_file.syntax());
 
-                self.visit(source_file.syntax(), &semantics);
+                self.walk(source_file.syntax(), &semantics);
 
                 changes.insert(file_id, self.upgrader.finish());
             }


### PR DESCRIPTION
This way we avoid breaking the typed `fn visit_*` method dispatch by overriding `fn visit` in a `Visitor`.

I then renamed `fn visit` to `fn pre_visit` to nicely match `fn post_visit` and to better reflect the behavior.

`fn pre_visit`/`fn post_visit` now provide untyped customization points for optional preparation/cleanup per visit.